### PR TITLE
Remove license

### DIFF
--- a/data/share/man/man1/mw.1
+++ b/data/share/man/man1/mw.1
@@ -117,10 +117,6 @@ Prints a list of all command keywords
 recognizes, along with a brief description. Keywords that accept arguments
 are followed by their arguments in 
 .IR [brackets] .
-.IP license
-Prints
-.BR mw 's
-license.
 .IP show
 Prints a text graphic of the sound presently at the top of the editor stack. 
 This include a waveform bargraph of the sound's amplitiude with respect to 

--- a/mw/app.py
+++ b/mw/app.py
@@ -28,13 +28,6 @@ class App:
         readline.set_completer(completer)
         readline.parse_and_bind("tab: complete")
 
-    def license(self) -> str:
-        module_dir = list(split(__file__)[:-2])
-        license_path_list = module_dir + ["LICENSE"]
-        license_path = join(*license_path_list)
-        with open(license_path) as f:
-            return f.read()
-
     def get_input(self):
         selection = []
 

--- a/mw/commands.py
+++ b/mw/commands.py
@@ -179,9 +179,9 @@ class CommandHandler:
                 pnames = "[" + ",".join(pnames) + "]"
                 print(f"{f} {pnames}".ljust(15) + f": {m.__doc__}")
     
-    def license(self, app: 'mw.app.App'):
-        "Print the license"
-        print(app.license())
+    # def license(self, app: 'mw.app.App'):
+    #     "Print the license"
+    #     print(app.license())
  
     def stack(self, app: 'mw.app.App'):
         "Print the stack"

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -21,9 +21,9 @@ class TestCommands(TestCase):
         self.mock_app.stack.reset_mock()
         return super().tearDown()
     
-    def test_license(self):
-        self.command_handler.license(self.mock_app)
-        self.mock_app.license.assert_called()
+    # def test_license(self):
+    #     self.command_handler.license(self.mock_app)
+    #     self.mock_app.license.assert_called()
     
     def test_help(self):
         self.command_handler.help(self.mock_app)


### PR DESCRIPTION
Removed `license` command from the command interpreter. The LICENSE file isn't installed by pip and copying the license into the source isn't worth the trouble I think.